### PR TITLE
send connection reset on window error

### DIFF
--- a/src/proto/streams/flow_control.rs
+++ b/src/proto/streams/flow_control.rs
@@ -46,6 +46,8 @@ pub struct FlowControl {
     /// This can go negative if a user declares a smaller target window than
     /// the peer knows about.
     available: Window,
+
+    pub error: u8,
 }
 
 impl FlowControl {
@@ -53,6 +55,7 @@ impl FlowControl {
         FlowControl {
             window_size: Window(0),
             available: Window(0),
+            error: 0,
         }
     }
 

--- a/src/proto/streams/prioritize.rs
+++ b/src/proto/streams/prioritize.rs
@@ -742,17 +742,34 @@ impl Prioritize {
                             let len =
                                 cmp::min(len, stream_capacity.as_size() as usize) as WindowSize;
 
-                            // There *must* be be enough connection level
-                            // capacity at this point.
-                            debug_assert!(len <= self.flow.window_size());
+                            // we are about to hit the asserts below and there is no good path out
+                            // so try to use the workaround above and hope for the best
+                            if len > self.flow.window_size() || len > stream.send_flow.window_size()
+                            {
+                                if self.flow.error < 32 {
+                                    self.flow.error += 1;
+                                    tracing::error!(
+                                        len,
+                                        flow_window = %self.flow.window_size(),
+                                        stream_window = &stream.send_flow.window_size(),
+                                        window = %stream_capacity,
+                                        available = %stream.send_flow.available(),
+                                        requested = stream.requested_send_capacity,
+                                        buffered = stream.buffered_send_data,
+                                        flow = ?self.flow,
+                                        stream = ?stream,
+                                        "window size error"
+                                    );
+                                }
 
-                            // Check if the stream level window the peer knows is available. In some
-                            // scenarios, maybe the window we know is available but the window which
-                            // peer knows is not.
-                            if len > 0 && len > stream.send_flow.window_size() {
                                 stream.pending_send.push_front(buffer, frame.into());
                                 continue;
                             }
+
+                            // There *must* be be enough connection level
+                            // capacity at this point.
+                            debug_assert!(len <= self.flow.window_size());
+                            debug_assert!(len <= stream.send_flow.window_size());
 
                             tracing::trace!(len, "sending data frame");
 


### PR DESCRIPTION


There is some connection/stream capacity management issue that leads to attempt to send a data frame larger than the available window. An attempt to account for the sent frame in this case leads to an assertion.
There was a previous attempt to fix this issue - on for a stream capacity. We still have seen the assert bei ng hit at the connection level.

It may be a good idea to treat this as an error and propagate it out - but there is no error path at this point and the caller context is murky, and creating a new error path is really quirky.

The previous attempt for a fix mimicked the code a few lines above that also seems to be dealing with the lack of allocated capacity - the approach is to re-queue the frame into the stream and continue. The stream is supposed to be rescheduled on new i/o, window update or capacity becoming available - it is not really obvious if condition will self resolve or some streams may become stuck, fingers crossed.

The main goal is to produce some logs.
